### PR TITLE
CTRL-C will now exit the program for real

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,9 @@ const glob = require('glob');
 
 let files;
 
+let shuttingDown = false;
+let writing = false;
+
 const app = express()
 app.use(cors());
 app.use(bodyParser.urlencoded({extended: true}));
@@ -20,23 +23,35 @@ app.get('/', (req, res) => {
 app.post('/save', (req, res) => {
   const changes = req.body;
 
-  // Prompt to confirm.
-  console.log([
-    `\nA-Frame Inspector from ${req.hostname} has requested the following changes:\n`,
-    `${prettyPrintChanges(changes)}`,
-    'Do you allow the A-Frame Inspector Watcher to write these updates directly ' +
-    'within this directory?'
-  ].join('\n'));
+  if (!shuttingDown)
+  {
+    // Prompt to confirm.
+    console.log([
+      `\nA-Frame Inspector from ${req.hostname} has requested the following changes:\n`,
+      `${prettyPrintChanges(changes)}`,
+      'Do you allow the A-Frame Inspector Watcher to write these updates directly ' +
+      'within this directory?'
+    ].join('\n'));
 
-  const prompt = new Confirm('Y/n');
-  prompt.run().then(answer => {
-    // Denied.
-    if (!answer) { res.sendStatus(403); }
+    const prompt = new Confirm('Y/n');
+    prompt.run().then(answer => {
+      // Denied.
+      if (!answer) { res.sendStatus(403); }
 
-    // Accepted.
-    sync(changes);
-    res.sendStatus(200);
-  });
+      // Accepted.
+      writing = true;
+      sync(changes);
+      res.sendStatus(200);
+      writing = false;
+    });
+  }
+  else
+  {
+    //Shutting down, no writing allowed
+    res.sendStatus(403);
+  }
+
+  
 });
 
 function prettyPrintChanges (changes) {
@@ -202,3 +217,20 @@ if (process.env.NODE_ENV !== 'test') {
       'Try passing a directory or wildcard pointing to HTML files (e.g., **/*.html).');
   }
 }
+
+process.on('SIGINT', function() {
+  console.log("\nGracefully shutting down from SIGINT (Ctrl+C)");
+
+  //Prevents
+  shuttingDown = true;
+
+  //Add whatever needs to be taken care of before shutdown
+
+  if (writing)
+  {
+    console.log("Warning, shutdown occured during writing. Affected files could have been mangled!")
+  }
+
+  console.log("Exiting...");
+  process.exit();
+});

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 const bodyParser = require('body-parser');
-const Confirm = require('prompt-confirm');
+const { Confirm } = require('enquirer');
 const cors = require('cors');
 const express = require('express');
 const fs = require('fs');
@@ -26,14 +26,17 @@ app.post('/save', (req, res) => {
   if (!shuttingDown)
   {
     // Prompt to confirm.
-    console.log([
+    const msg = [
       `\nA-Frame Inspector from ${req.hostname} has requested the following changes:\n`,
       `${prettyPrintChanges(changes)}`,
       'Do you allow the A-Frame Inspector Watcher to write these updates directly ' +
       'within this directory?'
-    ].join('\n'));
+    ].join('\n');
 
-    const prompt = new Confirm('Y/n');
+    const prompt = new Confirm({
+      type: 'confirm',
+      message: msg
+    });
     prompt.run().then(answer => {
       // Denied.
       if (!answer) { res.sendStatus(403); }

--- a/package.json
+++ b/package.json
@@ -27,14 +27,14 @@
     "body-parser": "^1.18.3",
     "chai": "^4.2.0",
     "cors": "^2.8.5",
+    "enquirer": "^2.3.6",
     "express": "^4.16.4",
     "glob": "^7.1.3",
     "lodash": "^4.17.11",
     "lodash.uniq": "^4.5.0",
     "mocha": "^5.2.0",
     "nodemon": "^1.18.7",
-    "prompt": "^1.0.0",
-    "prompt-confirm": "^2.0.4"
+    "prompt": "^1.0.0"
   },
   "bin": {
     "aframe-watcher": "./index.js"


### PR DESCRIPTION
Built on top of #16 

Replace deprecated prompt-confirm package for enquirer.
    
Allows SIGINT signal passing. So we can kill the process using Ctrl-C